### PR TITLE
task名を"write app"に変更／macとubuntuに対応

### DIFF
--- a/app_iothub_client/.vscode/tasks.json
+++ b/app_iothub_client/.vscode/tasks.json
@@ -140,7 +140,25 @@
             }
         },
         {
-            "label": "write mbed drive",
+            "label": "write app",
+            "linux": {
+                "command": "rsync",
+                "args": [
+                    "-av",
+                    "--progress",
+                    "${workspaceRoot}/Debug/app_iothub_client.bin",
+                    "/media/${env:USER}/MBED/"
+                ]
+            },
+            "osx": {
+                "command": "rsync",
+                "args": [
+                    "-av",
+                    "--progress",
+                    "${workspaceRoot}/Debug/app_iothub_client.bin",
+                    "/Volumes/MBED/"
+                ]
+            },
             "windows": {
                 "command": "C:\\Windows\\System32\\robocopy.exe",
                 "args": [


### PR DESCRIPTION
当方のmacとUbuntuで動作確認済みです

忘れないようにハンズオン資料のことをここにも書いておくと，
P.31: "wriite mbed drive" -> "write app"に変更が必要です
P.11,12: mbed_tlsブランチにもmergeが必要です